### PR TITLE
Rename server name to tm.local

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,5 +1,5 @@
 server {
-    server_name tm.dev;
+    server_name tm.local;
     root /var/www/html;
     index index.php;
 


### PR DESCRIPTION
Proposal to prevent issues on Chrome. 

Am I right that after changes like that we should remove container `docker rm ID` and start them once more?