### PR TITLE
Add change task status scenarios - with separate domain logic

### DIFF
--- a/taskmanager/features/bootstrap/FeatureContext.php
+++ b/taskmanager/features/bootstrap/FeatureContext.php
@@ -8,6 +8,7 @@ use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
 use App\Application\Task\Task;
 use App\Application\User\User;
+use App\Infrastructure\InMemory\MessageBag;
 use App\Infrastructure\InMemory\TaskRegistry;
 use App\Infrastructure\InMemory\UserRegistry;
 use App\Application\Task\UnexpectedStatusChangeException;
@@ -22,6 +23,9 @@ class FeatureContext implements Context
 
     /** @var UserRegistry */
     private $userRegistry;
+
+    /** @var MessageBag */
+    private $messageBag;
 
     /**
      * Initializes context.
@@ -92,6 +96,14 @@ class FeatureContext implements Context
     public function thereIsNoTasks()
     {
         $this->taskRegistry = new TaskRegistry();
+    }
+
+    /**
+     * @Given there is no notifications
+     */
+    public function thereIsNoNotifications()
+    {
+        $this->messageBag = new MessageBag();
     }
 
     /**
@@ -253,7 +265,7 @@ class FeatureContext implements Context
     }
 
     /**
-     * @Then task named :task should have status :status
+     * @Then task named :task (still) should have status :status
      */
     public function taskNamedShouldHaveStatus(Task $task, Status $status)
     {
@@ -271,22 +283,26 @@ class FeatureContext implements Context
     }
 
     /**
-     * @When task :exception is thrown during user named :user is changing task named :task status change to :status
+     * @When user named :user tries to change task named :task status to :status
      */
-    public function taskIsThrownDuringUserNamedIsChangingTaskNamedStatusChangeTo(
-        UnexpectedStatusChangeException $exception,
-        User $user,
-        Task $task,
-        Status $status
-    ) {
+    public function userNamedTriesToChangeTaskNamedStatus(User $user, Task $task, Status $status)
+    {
         try {
             $task->setStatus($status, $user);
-        } catch (\Exception $thrownException) {
-            Assert::assertEquals($exception, $thrownException);
-
-            return;
+        } catch (UnexpectedStatusChangeException $exception) {
+            $this->messageBag->add($exception->getMessage());
         }
+    }
 
-        Assert::fail(sprintf('Expected exception %s was not raised.', UnexpectedStatusChangeException::class));
+    /**
+     * @Then user named :user should see notice that changing closed task status is disallowed
+     */
+    public function userNamedShouldSeeNoticeThatChangingClosedTaskStatusIsDisallowed(User $user)
+    {
+        $exception = UnexpectedStatusChangeException::createForClosedStatus();
+
+        Assert::assertTrue(
+            $this->messageBag->has($exception->getMessage())
+        );
     }
 }

--- a/taskmanager/features/bootstrap/FeatureContext.php
+++ b/taskmanager/features/bootstrap/FeatureContext.php
@@ -7,11 +7,12 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
 use App\Application\Task\Task;
+use App\Application\Task\UnexpectedStatusChangeException;
 use App\Application\User\User;
+use App\Application\DomainManager\TaskStatusManager;
 use App\Infrastructure\InMemory\MessageBag;
 use App\Infrastructure\InMemory\TaskRegistry;
 use App\Infrastructure\InMemory\UserRegistry;
-use App\Application\Task\UnexpectedStatusChangeException;
 
 /**
  * Defines application features from the specific context.
@@ -27,6 +28,9 @@ class FeatureContext implements Context
     /** @var MessageBag */
     private $messageBag;
 
+    /** @var TaskStatusManager */
+    private $taskStatusManager;
+
     /**
      * Initializes context.
      *
@@ -37,6 +41,7 @@ class FeatureContext implements Context
     public function __construct()
     {
         $this->taskRegistry = new TaskRegistry();
+        $this->taskStatusManager = new TaskStatusManager();
     }
 
     /**
@@ -261,7 +266,7 @@ class FeatureContext implements Context
      */
     public function userNamedChangesTaskNamedStatusTo(User $user, Task $task, Status $status)
     {
-        $task->setStatus($status, $user);
+        $this->taskStatusManager->changeTaskStatusByUser($task, $status, $user);
     }
 
     /**
@@ -288,7 +293,7 @@ class FeatureContext implements Context
     public function userNamedTriesToChangeTaskNamedStatus(User $user, Task $task, Status $status)
     {
         try {
-            $task->setStatus($status, $user);
+            $this->taskStatusManager->changeTaskStatusByUser($task, $status, $user);
         } catch (UnexpectedStatusChangeException $exception) {
             $this->messageBag->add($exception->getMessage());
         }

--- a/taskmanager/features/task.feature
+++ b/taskmanager/features/task.feature
@@ -9,9 +9,9 @@ Feature: Task management
       | Name  |
       | Sarah |
       | Carl  |
+    And there is no tasks
 
   Scenario: Create a simple task
-    Given there is no tasks
     When I create a task named "Add switch language button"
     Then there should be "1" tasks with "TODO" status
     And task should have create date
@@ -72,5 +72,5 @@ Feature: Task management
 
   Scenario: Change task status from CLOSED to TODO
     Given there is a task named "Add switch language button" with "CLOSED" status
-    When user named "Sarah" changes task named "Add switch language button" status to "TODO"
+    When task "UnexpectedStatusChangeException" is thrown during user named "Sarah" is changing task named "Add switch language button" status change to "TODO"
     Then task named "Add switch language button" should have status "CLOSED"

--- a/taskmanager/features/task.feature
+++ b/taskmanager/features/task.feature
@@ -10,6 +10,7 @@ Feature: Task management
       | Sarah |
       | Carl  |
     And there is no tasks
+    And there is no notifications
 
   Scenario: Create a simple task
     When I create a task named "Add switch language button"
@@ -72,5 +73,6 @@ Feature: Task management
 
   Scenario: Change task status from CLOSED to TODO
     Given there is a task named "Add switch language button" with "CLOSED" status
-    When task "UnexpectedStatusChangeException" is thrown during user named "Sarah" is changing task named "Add switch language button" status change to "TODO"
-    Then task named "Add switch language button" should have status "CLOSED"
+    When user named "Sarah" tries to change task named "Add switch language button" status to "TODO"
+    Then task named "Add switch language button" still should have status "CLOSED"
+    And user named "Sarah" should see notice that changing closed task status is disallowed

--- a/taskmanager/features/task.feature
+++ b/taskmanager/features/task.feature
@@ -27,12 +27,47 @@ Feature: Task management
     When I assigned task named "Add switch language button" to user named "Sarah"
     Then task named "Add switch language button" should be assigned to user named "Sarah"
 
-    Scenario: Update task priority
-      Given there is unassigned task named "Change priority test"
-      When I change task named "Change priority test" priority to "Critical"
-      Then task named "Change priority test" should have priority value equal to "Critical"
+  Scenario: Update task priority
+    Given there is unassigned task named "Change priority test"
+    When I change task named "Change priority test" priority to "Critical"
+    Then task named "Change priority test" should have priority value equal to "Critical"
 
-    Scenario: Delete task
-      Given there is unassigned task named "Deleting test"
-      When I remove task named "Deleting test"
-      Then task named "Deleting test" should no longer exist
+  Scenario: Delete task
+    Given there is unassigned task named "Deleting test"
+    When I remove task named "Deleting test"
+    Then task named "Deleting test" should no longer exist
+
+  Scenario: Assign already assigned task
+    Given there is task named "Add switch language button" assigned to user named "Carl"
+    When I assigned task named "Add switch language button" to user named "Sarah"
+    Then task named "Add switch language button" should be assigned to user named "Sarah"
+
+  Scenario: Change task status from TODO to IN PROGRESS
+    Given there is a task named "Add switch language button" with "TODO" status
+    When I move this task to "IN PROGRESS" column
+    Then there still will be "1" task
+    And it should have status "IN PROGRESS"
+
+  Scenario: Change task status from IN PROGRESS to DONE
+    Given there is a task named "Add switch language button" with "IN PROGRESS" status
+    When I move this task to "DONE" column
+    Then there still will be "1" task
+    And it should have status "DONE"
+
+  Scenario: Change task status from DONE to CLOSED
+    Given there is a task named "Add switch language button" with "DONE" status
+    When I move this task to "CLOSED" column
+    Then there still will be "1" task
+    And it should have status "CLOSED"
+
+  Scenario: Change task status from IN PROGRESS to TODO
+    Given there is a task named "Add switch language button" with "IN PROGRESS" status
+    When I move this task to "TODO" column
+    Then there still will be "1" task
+    And it should have status "TODO"
+
+  Scenario: Change task status from DONE to IN PROGRESS
+    Given there is a task named "Add switch language button" with "DONE" status
+    When I move this task to "IN PROGRESS" column
+    Then there still will be "1" task
+    And it should have status "IN PROGRESS"

--- a/taskmanager/features/task.feature
+++ b/taskmanager/features/task.feature
@@ -44,30 +44,33 @@ Feature: Task management
 
   Scenario: Change task status from TODO to IN PROGRESS
     Given there is a task named "Add switch language button" with "TODO" status
-    When I move this task to "IN PROGRESS" column
-    Then there still will be "1" task
-    And it should have status "IN PROGRESS"
+    When user named "Sarah" changes task named "Add switch language button" status to "IN PROGRESS"
+    Then task named "Add switch language button" should have status "IN PROGRESS"
+    And task named "Add switch language button" should be assigned to user named "Sarah"
 
   Scenario: Change task status from IN PROGRESS to DONE
     Given there is a task named "Add switch language button" with "IN PROGRESS" status
-    When I move this task to "DONE" column
-    Then there still will be "1" task
-    And it should have status "DONE"
+    When user named "Sarah" changes task named "Add switch language button" status to "DONE"
+    Then task named "Add switch language button" should have status "DONE"
 
   Scenario: Change task status from DONE to CLOSED
     Given there is a task named "Add switch language button" with "DONE" status
-    When I move this task to "CLOSED" column
-    Then there still will be "1" task
-    And it should have status "CLOSED"
+    When user named "Sarah" changes task named "Add switch language button" status to "CLOSED"
+    Then task named "Add switch language button" should have status "CLOSED"
 
   Scenario: Change task status from IN PROGRESS to TODO
     Given there is a task named "Add switch language button" with "IN PROGRESS" status
-    When I move this task to "TODO" column
-    Then there still will be "1" task
-    And it should have status "TODO"
+    When user named "Sarah" changes task named "Add switch language button" status to "TODO"
+    Then task named "Add switch language button" should have status "TODO"
+    And task named "Add switch language button" should be unassigned
 
   Scenario: Change task status from DONE to IN PROGRESS
     Given there is a task named "Add switch language button" with "DONE" status
-    When I move this task to "IN PROGRESS" column
-    Then there still will be "1" task
-    And it should have status "IN PROGRESS"
+    When user named "Sarah" changes task named "Add switch language button" status to "IN PROGRESS"
+    Then task named "Add switch language button" should have status "IN PROGRESS"
+    And task named "Add switch language button" should be assigned to user named "Sarah"
+
+  Scenario: Change task status from CLOSED to TODO
+    Given there is a task named "Add switch language button" with "CLOSED" status
+    When user named "Sarah" changes task named "Add switch language button" status to "TODO"
+    Then task named "Add switch language button" should have status "CLOSED"

--- a/taskmanager/spec/Application/DomainManager/TaskStatusManagerSpec.php
+++ b/taskmanager/spec/Application/DomainManager/TaskStatusManagerSpec.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace spec\App\Application\DomainManager;
+
+use App\Application\DomainManager\TaskStatusManager;
+use App\Application\Task\Status;
+use App\Application\Task\Task;
+use App\Application\User\User;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TaskStatusManagerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(TaskStatusManager::class);
+    }
+
+    function it_shoul_have_possibility_to_change_task_status(Task $task, Status $status, User $user)
+    {
+        $status->equals(Argument::any())->willReturn(false);
+
+        $this->changeTaskStatusByUser($task, $status, $user);
+    }
+}

--- a/taskmanager/spec/Application/Task/StatusSpec.php
+++ b/taskmanager/spec/Application/Task/StatusSpec.php
@@ -34,4 +34,22 @@ class StatusSpec extends ObjectBehavior
     {
         $this->shouldReturnAnInstanceOf(Status::class);
     }
+
+    function it_should_has_in_progress_static_contstructor()
+    {
+        $this->beConstructedThrough('inProgress');
+        $this->shouldReturnAnInstanceOf(Status::class);
+    }
+
+    function it_should_has_done_static_contstructor()
+    {
+        $this->beConstructedThrough('done');
+        $this->shouldReturnAnInstanceOf(Status::class);
+    }
+
+    function it_should_has_closed_static_contstructor()
+    {
+        $this->beConstructedThrough('closed');
+        $this->shouldReturnAnInstanceOf(Status::class);
+    }
 }

--- a/taskmanager/spec/Application/Task/TaskSpec.php
+++ b/taskmanager/spec/Application/Task/TaskSpec.php
@@ -65,35 +65,9 @@ class TaskSpec extends ObjectBehavior
         $this->getPriority()->shouldReturn(Task::PRIORITY_MAJOR);
     }
 
-    function it_should_be_possible_to_change_status_to_todo()
+    function it_should_be_possible_to_change_status(Status $status)
     {
-        $status = Status::toDo();
         $this->setStatus($status);
-
-        $this->getStatus()->shouldBeEqualTo($status);
-    }
-
-    function it_should_be_possible_to_change_status_to_in_progress()
-    {
-        $status = Status::inProgress();
-        $this->setStatus($status);
-
-        $this->getStatus()->shouldBeEqualTo($status);
-    }
-
-    function it_should_be_possible_to_change_status_to_done()
-    {
-        $status = Status::done();
-        $this->setStatus($status);
-
-        $this->getStatus()->shouldBeEqualTo($status);
-    }
-
-    function it_should_be_possible_to_change_status_to_closed()
-    {
-        $status = Status::closed();
-        $this->setStatus($status);
-
         $this->getStatus()->shouldBeEqualTo($status);
     }
 }

--- a/taskmanager/spec/Application/Task/TaskSpec.php
+++ b/taskmanager/spec/Application/Task/TaskSpec.php
@@ -64,4 +64,36 @@ class TaskSpec extends ObjectBehavior
     {
         $this->getPriority()->shouldReturn(Task::PRIORITY_MAJOR);
     }
+
+    function it_should_be_possible_to_change_status_to_todo()
+    {
+        $status = Status::toDo();
+        $this->setStatus($status);
+
+        $this->getStatus()->shouldBeEqualTo($status);
+    }
+
+    function it_should_be_possible_to_change_status_to_in_progress()
+    {
+        $status = Status::inProgress();
+        $this->setStatus($status);
+
+        $this->getStatus()->shouldBeEqualTo($status);
+    }
+
+    function it_should_be_possible_to_change_status_to_done()
+    {
+        $status = Status::done();
+        $this->setStatus($status);
+
+        $this->getStatus()->shouldBeEqualTo($status);
+    }
+
+    function it_should_be_possible_to_change_status_to_closed()
+    {
+        $status = Status::closed();
+        $this->setStatus($status);
+
+        $this->getStatus()->shouldBeEqualTo($status);
+    }
 }

--- a/taskmanager/spec/Application/Task/TaskSpec.php
+++ b/taskmanager/spec/Application/Task/TaskSpec.php
@@ -4,6 +4,7 @@ namespace spec\App\Application\Task;
 
 use App\Application\Task\Status;
 use App\Application\Task\Task;
+use App\Application\Task\UnexpectedStatusChangeException;
 use App\Application\User\UnassignedUserException;
 use App\Application\User\User;
 use PhpSpec\ObjectBehavior;
@@ -65,9 +66,45 @@ class TaskSpec extends ObjectBehavior
         $this->getPriority()->shouldReturn(Task::PRIORITY_MAJOR);
     }
 
-    function it_should_be_possible_to_change_status(Status $status)
+    function it_should_be_possible_to_change_status(User $user)
     {
-        $this->setStatus($status);
-        $this->getStatus()->shouldBeEqualTo($status);
+        $this->beConstructedWith(
+            "Add switch language button",
+            Status::toDo()
+        );
+
+        $status = Status::done();
+
+        $this->setStatus($status, $user);
+        $this->getStatus()->shouldReturn($status);
+    }
+
+    function it_should_have_assigned_user_after_change_status_to_in_progress(User $user)
+    {
+        $this->beConstructedWith(
+            "Add switch language button",
+            Status::toDo()
+        );
+        $this->setStatus(Status::inProgress(), $user);
+        $this->assigned()->shouldReturn($user);
+    }
+
+    function it_should_not_have_assigned_user_after_change_status_to_todo(User $user)
+    {
+        $this->beConstructedWith(
+            "Add switch language button",
+            Status::inProgress()
+        );
+        $this->setStatus(Status::toDo(), $user);
+        $this->hasAssignment()->shouldReturn(false);
+    }
+
+    function it_should_throw_exception_when_status_is_changed_from_close(User $user)
+    {
+        $this->beConstructedWith(
+            "Add switch language button",
+            Status::closed()
+        );
+        $this->shouldThrow(UnexpectedStatusChangeException::class)->duringSetStatus(Status::toDo(), $user);
     }
 }

--- a/taskmanager/spec/Application/Task/TaskSpec.php
+++ b/taskmanager/spec/Application/Task/TaskSpec.php
@@ -79,26 +79,6 @@ class TaskSpec extends ObjectBehavior
         $this->getStatus()->shouldReturn($status);
     }
 
-    function it_should_have_assigned_user_after_change_status_to_in_progress(User $user)
-    {
-        $this->beConstructedWith(
-            "Add switch language button",
-            Status::toDo()
-        );
-        $this->setStatus(Status::inProgress(), $user);
-        $this->assigned()->shouldReturn($user);
-    }
-
-    function it_should_not_have_assigned_user_after_change_status_to_todo(User $user)
-    {
-        $this->beConstructedWith(
-            "Add switch language button",
-            Status::inProgress()
-        );
-        $this->setStatus(Status::toDo(), $user);
-        $this->hasAssignment()->shouldReturn(false);
-    }
-
     function it_should_throw_exception_when_status_is_changed_from_close(User $user)
     {
         $this->beConstructedWith(

--- a/taskmanager/spec/Application/Task/UnexpectedStatusChangeExceptionSpec.php
+++ b/taskmanager/spec/Application/Task/UnexpectedStatusChangeExceptionSpec.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace spec\App\Application\Task;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Console\Exception\LogicException;
+
+class UnexpectedStatusChangeExceptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('App\Application\Task\UnexpectedStatusChangeException');
+        $this->shouldBeAnInstanceOf(\LogicException::class);
+    }
+
+    function it_should_have_factory_method_for_closed_status()
+    {
+        $this::beConstructedThrough('createForClosedStatus');
+        $this->shouldHaveType('App\Application\Task\UnexpectedStatusChangeException');
+        $this->shouldBeAnInstanceOf(\LogicException::class);
+    }
+}

--- a/taskmanager/spec/Infrastructure/InMemory/MessageBagSpec.php
+++ b/taskmanager/spec/Infrastructure/InMemory/MessageBagSpec.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace spec\App\Infrastructure\InMemory;
+
+use App\Application\Message\MessageBag;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class MessageBagSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldImplement(MessageBag::class);
+    }
+
+    function it_should_have_possibility_to_add_message()
+    {
+        $this->add('message');
+    }
+
+    function it_should_have_possibility_to_check_if_message_exists()
+    {
+        $this->has('message')->shouldBeBool();
+    }
+}

--- a/taskmanager/src/Application/DomainManager/TaskStatusManager.php
+++ b/taskmanager/src/Application/DomainManager/TaskStatusManager.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace App\Application\DomainManager;
+
+use App\Application\Task\Status;
+use App\Application\Task\Task;
+use App\Application\User\User;
+
+class TaskStatusManager
+{
+    public function changeTaskStatusByUser(Task $task, Status $status, User $user): void
+    {
+        $task->setStatus($status);
+
+        if ($status->equals(Status::inProgress())) {
+            $task->assign($user);
+        } elseif ($status->equals(Status::toDo())) {
+            $task->unassign();
+        }
+    }
+}

--- a/taskmanager/src/Application/Message/MessageBag.php
+++ b/taskmanager/src/Application/Message/MessageBag.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace App\Application\Message;
+
+interface MessageBag
+{
+    public function add(string $message): void;
+
+    public function has(string $message): bool;
+}

--- a/taskmanager/src/Application/Task/Status.php
+++ b/taskmanager/src/Application/Task/Status.php
@@ -5,6 +5,9 @@ namespace App\Application\Task;
 class Status
 {
     private const TODO = 'TODO';
+    private const IN_PROGRESS = 'IN PROGRESS';
+    private const DONE = 'DONE';
+    private const CLOSED = 'CLOSED';
 
     private $status;
 
@@ -26,5 +29,20 @@ class Status
     public static function toDo(): self
     {
         return new self(self::TODO);
+    }
+
+    public static function inProgress(): self
+    {
+        return new self(self::IN_PROGRESS);
+    }
+
+    public static function done(): self
+    {
+        return new self(self::DONE);
+    }
+
+    public static function closed(): self
+    {
+        return new self(self::CLOSED);
     }
 }

--- a/taskmanager/src/Application/Task/Task.php
+++ b/taskmanager/src/Application/Task/Task.php
@@ -57,23 +57,13 @@ class Task
         return $this->status;
     }
 
-    public function setStatus(Status $status, User $user): void
+    public function setStatus(Status $status): void
     {
-        if ($this->status->equals($status)) {
-            return;
-        }
-
         if ($this->status->equals(Status::closed())) {
             throw UnexpectedStatusChangeException::createForClosedStatus();
         }
 
         $this->status = $status;
-
-        if ($this->status->equals(Status::inProgress())) {
-            $this->assign($user);
-        } elseif ($this->status->equals(Status::toDo())) {
-            $this->unassign();
-        }
     }
 
     /**

--- a/taskmanager/src/Application/Task/Task.php
+++ b/taskmanager/src/Application/Task/Task.php
@@ -57,9 +57,23 @@ class Task
         return $this->status;
     }
 
-    public function setStatus(Status $status)
+    public function setStatus(Status $status, User $user): void
     {
+        if ($this->status->equals($status)) {
+            return;
+        }
+
+        if ($this->status->equals(Status::closed())) {
+            throw UnexpectedStatusChangeException::createForClosedStatus();
+        }
+
         $this->status = $status;
+
+        if ($this->status->equals(Status::inProgress())) {
+            $this->assign($user);
+        } elseif ($this->status->equals(Status::toDo())) {
+            $this->unassign();
+        }
     }
 
     /**

--- a/taskmanager/src/Application/Task/Task.php
+++ b/taskmanager/src/Application/Task/Task.php
@@ -95,6 +95,11 @@ class Task
         $this->update();
     }
 
+    public function unassign(): void
+    {
+        $this->user = null;
+    }
+
     public function hasAssignment(): bool
     {
         return $this->user !== null;

--- a/taskmanager/src/Application/Task/Task.php
+++ b/taskmanager/src/Application/Task/Task.php
@@ -57,6 +57,11 @@ class Task
         return $this->status;
     }
 
+    public function setStatus(Status $status)
+    {
+        $this->status = $status;
+    }
+
     /**
      * @return string
      */

--- a/taskmanager/src/Application/Task/UnexpectedStatusChangeException.php
+++ b/taskmanager/src/Application/Task/UnexpectedStatusChangeException.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace App\Application\Task;
+
+class UnexpectedStatusChangeException extends \LogicException
+{
+    public static function createForClosedStatus()
+    {
+        return new self('Cannot change closed task status.');
+    }
+}

--- a/taskmanager/src/Infrastructure/InMemory/MessageBag.php
+++ b/taskmanager/src/Infrastructure/InMemory/MessageBag.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace App\Infrastructure\InMemory;
+
+use \App\Application\Message\MessageBag as BaseMessageBag;
+
+class MessageBag implements BaseMessageBag
+{
+    /** @var string[] */
+    private $messages = [];
+
+    public function add(string $message): void
+    {
+        $this->messages[] = $message;
+    }
+
+    public function has(string $message): bool
+    {
+        return array_search($message, $this->messages) !== false;
+    }
+}

--- a/taskmanager/src/Infrastructure/InMemory/TaskRegistry.php
+++ b/taskmanager/src/Infrastructure/InMemory/TaskRegistry.php
@@ -5,9 +5,8 @@ namespace App\Infrastructure\InMemory;
 use App\Application\Task\Status;
 use App\Application\Task\Task;
 use App\Application\Task\TaskRegistry as BaseTaskRegistry;
-use Countable;
 
-class TaskRegistry implements BaseTaskRegistry, Countable
+class TaskRegistry implements BaseTaskRegistry
 {
     private $tasks = [];
 
@@ -41,10 +40,5 @@ class TaskRegistry implements BaseTaskRegistry, Countable
     public function remove(Task $task): void
     {
         unset($this->tasks[(string)$task->getId()]);
-    }
-
-    public function count(): int
-    {
-        return count($this->tasks);
     }
 }

--- a/taskmanager/src/Infrastructure/InMemory/TaskRegistry.php
+++ b/taskmanager/src/Infrastructure/InMemory/TaskRegistry.php
@@ -5,8 +5,9 @@ namespace App\Infrastructure\InMemory;
 use App\Application\Task\Status;
 use App\Application\Task\Task;
 use App\Application\Task\TaskRegistry as BaseTaskRegistry;
+use Countable;
 
-class TaskRegistry implements BaseTaskRegistry
+class TaskRegistry implements BaseTaskRegistry, Countable
 {
     private $tasks = [];
 
@@ -40,5 +41,10 @@ class TaskRegistry implements BaseTaskRegistry
     public function remove(Task $task): void
     {
         unset($this->tasks[(string)$task->getId()]);
+    }
+
+    public function count(): int
+    {
+        return count($this->tasks);
     }
 }


### PR DESCRIPTION
This is an alternative solution for #17 with separated logic from model.